### PR TITLE
Fix build

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.7
-FROM debian:bullseye
+FROM debian:bookworm
 
 dependencies:
     RUN apt-get update

--- a/Earthfile
+++ b/Earthfile
@@ -6,7 +6,7 @@ dependencies:
     RUN apt-get install -y --no-install-recommends \
         git \
         subversion \
-        python \
+        python3 \
         build-essential \
         gawk \
         unzip \
@@ -15,6 +15,7 @@ dependencies:
         libssl-dev \
         wget \
         time \
+        rsync \
         ca-certificates \
         file
     RUN adduser builder

--- a/Earthfile
+++ b/Earthfile
@@ -50,7 +50,7 @@ setup-ffnw-site:
     RUN git tag -d $ffnw_tag
     RUN git tag $ffnw_release
     RUN ./buildscript.sh patch
-    RUN ./buildscript.sh prepare GLUON_BRANCH stable
+    RUN ./buildscript.sh prepare GLUON_AUTOUPDATER_BRANCH stable
     RUN ./buildscript.sh prepare GLUON_RELEASE $ffnw_release
     RUN ./buildscript.sh prepare l2tp
 


### PR DESCRIPTION
This PR fixes the build (https://github.com/n-thumann/ffnw-fritzbox-3370-firmware-builder/actions/runs/5631835348/job/15259190504) by
- Replacing `` with `` (see https://git.ffnw.de/ffnw-firmware/siteconf/-/commit/4f9a79a77272c4179bb996770f2946eb54a11bbd)
- Installing `python3` and `rsync` for building

Additionally, I bumped the Debian version to Bookworm